### PR TITLE
http client with timeout, for long running requests

### DIFF
--- a/http_client.go
+++ b/http_client.go
@@ -1,0 +1,61 @@
+package httpretry
+
+import (
+	"net"
+	"net/http"
+	"time"
+)
+
+// ClientWithTimeout is an http client optimized for high throughput.  It times
+// out more agressively than the default http client in net/http as well as
+// setting deadlines on the TCP connection.
+//
+// Taken from s3gof3r:
+// https://github.com/rlmcpherson/s3gof3r/blob/1e759738ff170bd0381a848337db677dbdd6aa62/http_client.go
+//
+func ClientWithTimeout(timeout time.Duration) *http.Client {
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		Dial:  DialWithTimeout(timeout),
+		ResponseHeaderTimeout: timeout,
+		MaxIdleConnsPerHost:   10,
+	}
+	return &http.Client{Transport: transport}
+}
+
+// DialWithTimeout creates a Dial function that returns a connection with an
+// inactivity timeout for the given duration.  This is designed for long running
+// HTTP requests.
+func DialWithTimeout(timeout time.Duration) func(netw, addr string) (net.Conn, error) {
+	return func(netw, addr string) (net.Conn, error) {
+		c, err := net.DialTimeout(netw, addr, timeout)
+		if err != nil {
+			return nil, err
+		}
+		if tc, ok := c.(*net.TCPConn); ok {
+			tc.SetKeepAlive(true)
+			tc.SetKeepAlivePeriod(timeout)
+		}
+		return &deadlineConn{timeout, c}, nil
+	}
+}
+
+type deadlineConn struct {
+	Timeout time.Duration
+	net.Conn
+}
+
+func (c *deadlineConn) Read(b []byte) (int, error) {
+	if err := c.Conn.SetDeadline(time.Now().Add(c.Timeout)); err != nil {
+		return 0, err
+	}
+	return c.Conn.Read(b)
+}
+
+func (c *deadlineConn) Write(b []byte) (int, error) {
+	if err := c.Conn.SetDeadline(time.Now().Add(c.Timeout)); err != nil {
+		return 0, err
+	}
+
+	return c.Conn.Write(b)
+}

--- a/http_client_test.go
+++ b/http_client_test.go
@@ -1,0 +1,49 @@
+package httpretry
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestClientWithTimeout(t *testing.T) {
+	t.Parallel()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "5")
+		w.WriteHeader(200)
+		w.Write([]byte("a"))
+		time.Sleep(time.Duration(100 * time.Millisecond))
+		w.Write([]byte("b"))
+		time.Sleep(time.Duration(100 * time.Millisecond))
+		w.Write([]byte("c"))
+		time.Sleep(time.Duration(200 * time.Millisecond))
+		w.Write([]byte("d"))
+		time.Sleep(time.Duration(100 * time.Millisecond))
+		w.Write([]byte("e"))
+	}))
+	defer ts.Close()
+
+	req, err := http.NewRequest("GET", ts.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client := ClientWithTimeout(time.Duration(150 * time.Millisecond))
+	res, err := client.Do(req)
+	if err == nil {
+		by, err := ioutil.ReadAll(res.Body)
+		res.Body.Close()
+		if err != nil {
+			by = []byte(err.Error())
+		}
+
+		t.Fatalf("Expected error, got: %d // %s", res.StatusCode, string(by))
+	}
+
+	if e := err.Error(); !strings.Contains(e, "timeout") {
+		t.Fatalf("Unexpected error: %s", e)
+	}
+}


### PR DESCRIPTION
This client is useful for any long running http requests, not just S3.

See: https://github.com/rlmcpherson/s3gof3r/blob/1e759738ff170bd0381a848337db677dbdd6aa62/http_client.go
