### PR TITLE
Only expect 206 if a range header is sent

### DIFF
--- a/getter_test.go
+++ b/getter_test.go
@@ -44,6 +44,18 @@ func TestRetry(t *testing.T) {
 			head.Set("Content-Type", "text/plain")
 			head.Set("Content-Length", "5")
 			w.WriteHeader(200)
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			if v := r.Header.Get("Range"); v != "" {
+				t.Errorf("Unexpected Range header on request %d: %s", v, i)
+			}
+
+			head := w.Header()
+			head.Set("Test-Request", strconv.Itoa(i))
+			head.Set("Accept-Ranges", "bytes")
+			head.Set("Content-Type", "text/plain")
+			head.Set("Content-Length", "5")
+			w.WriteHeader(200)
 			w.Write([]byte("ab"))
 		},
 		func(w http.ResponseWriter, r *http.Request) {
@@ -115,7 +127,7 @@ func TestRetry(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	code, head, reader := testGetter(t, req, 0, 0, 500, 200, 206, 0, 500, 206)
+	code, head, reader := testGetter(t, req, 0, 0, 500, 200, 200, 206, 0, 500, 206)
 
 	if code != 200 {
 		t.Errorf("Unexpected status %d", code)


### PR DESCRIPTION
This prevents `httpretry` from erroring when it was unable to read any bytes from the first 200 response.  It would assume 206 was the correct response on the first retry, and would return:

```
Expected status code 206, got 200
```

This changes the code to expect 206 only if a Range header is sent in the request.
