### PR TITLE
Close response body when response is a 5xx error

### DIFF
--- a/getter.go
+++ b/getter.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"strconv"
 	"time"
@@ -235,6 +236,10 @@ func (g *HttpGetter) connect() error {
 		if res.StatusCode > 0 && (res.StatusCode < 500 || res.StatusCode > 599) {
 			g.setResponse(res)
 			g.b.Done()
+		} else {
+			// Drain the body, necessary for go <= 1.3
+			io.Copy(ioutil.Discard, res.Body)
+			res.Body.Close()
 		}
 
 		return fmt.Errorf("Expected status code %d, got %d", expectedStatus, res.StatusCode)


### PR DESCRIPTION
When the response is a 5xx type error the body needs to be closed or the application will leave the underlying file descriptors open. Draining the body is not necessary on Go 1.4+ but is still needed in environments running 1.3 or below.