### PR TITLE
Separate dial timeouts

### DIFF
--- a/http_client.go
+++ b/http_client.go
@@ -6,15 +6,22 @@ import (
 	"time"
 )
 
-// ClientWithTimeout is an http client optimized for high throughput.  It times
-// out more agressively than the default http client in net/http as well as
-// setting deadlines on the TCP connection.
-//
-// Taken from s3gof3r:
-// https://github.com/rlmcpherson/s3gof3r/blob/1e759738ff170bd0381a848337db677dbdd6aa62/http_client.go
-//
-func ClientWithTimeout(timeout time.Duration) *http.Client {
-	return ClientWithTimeouts(timeout, timeout, timeout)
+type dialer struct {
+	Timeout    time.Duration
+	KeepAlive  time.Duration
+	Inactivity time.Duration
+}
+
+func (d *dialer) Dial(netw, addr string) (net.Conn, error) {
+	c, err := net.DialTimeout(netw, addr, d.Timeout)
+	if err != nil {
+		return nil, err
+	}
+	if tc, ok := c.(*net.TCPConn); ok {
+		tc.SetKeepAlive(true)
+		tc.SetKeepAlivePeriod(d.KeepAlive)
+	}
+	return &deadlineConn{d.Inactivity, c}, nil
 }
 
 // ClientWithTimeout is an http client optimized for high throughput.  It times
@@ -24,11 +31,12 @@ func ClientWithTimeout(timeout time.Duration) *http.Client {
 // Taken from s3gof3r:
 // https://github.com/rlmcpherson/s3gof3r/blob/1e759738ff170bd0381a848337db677dbdd6aa62/http_client.go
 //
-func ClientWithTimeouts(dialTimeout, kaTimeout, actTimeout time.Duration) *http.Client {
+func ClientWithTimeout(timeout time.Duration) *http.Client {
+	dialer := NewDialer(timeout)
 	transport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
-		Dial:  DialWithTimeouts(dialTimeout, kaTimeout, actTimeout),
-		ResponseHeaderTimeout: actTimeout,
+		Dial:  dialer.Dial,
+		ResponseHeaderTimeout: dialer.Inactivity,
 		MaxIdleConnsPerHost:   10,
 	}
 	return &http.Client{Transport: transport}
@@ -38,24 +46,14 @@ func ClientWithTimeouts(dialTimeout, kaTimeout, actTimeout time.Duration) *http.
 // inactivity timeout for the given duration.  This is designed for long running
 // HTTP requests.
 func DialWithTimeout(timeout time.Duration) func(netw, addr string) (net.Conn, error) {
-	return DialWithTimeouts(timeout, timeout, timeout)
+	return NewDialer(timeout).Dial
 }
 
 // DialWithTimeouts creates a Dial function that returns a connection with
 // separate timeouts for dialing the connection, maintaining the keep-alive
 // connection, and inactivity.  This is designed for long running HTTP requests.
-func DialWithTimeouts(dialTimeout, kaTimeout, actTimeout time.Duration) func(netw, addr string) (net.Conn, error) {
-	return func(netw, addr string) (net.Conn, error) {
-		c, err := net.DialTimeout(netw, addr, dialTimeout)
-		if err != nil {
-			return nil, err
-		}
-		if tc, ok := c.(*net.TCPConn); ok {
-			tc.SetKeepAlive(true)
-			tc.SetKeepAlivePeriod(kaTimeout)
-		}
-		return &deadlineConn{actTimeout, c}, nil
-	}
+func NewDialer(timeout time.Duration) *dialer {
+	return &dialer{Timeout: timeout, KeepAlive: timeout, Inactivity: timeout}
 }
 
 type deadlineConn struct {

--- a/http_client.go
+++ b/http_client.go
@@ -14,10 +14,21 @@ import (
 // https://github.com/rlmcpherson/s3gof3r/blob/1e759738ff170bd0381a848337db677dbdd6aa62/http_client.go
 //
 func ClientWithTimeout(timeout time.Duration) *http.Client {
+	return ClientWithTimeouts(timeout, timeout, timeout)
+}
+
+// ClientWithTimeout is an http client optimized for high throughput.  It times
+// out more agressively than the default http client in net/http as well as
+// setting deadlines on the TCP connection.
+//
+// Taken from s3gof3r:
+// https://github.com/rlmcpherson/s3gof3r/blob/1e759738ff170bd0381a848337db677dbdd6aa62/http_client.go
+//
+func ClientWithTimeouts(dialTimeout, kaTimeout, actTimeout time.Duration) *http.Client {
 	transport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
-		Dial:  DialWithTimeout(timeout),
-		ResponseHeaderTimeout: timeout,
+		Dial:  DialWithTimeouts(dialTimeout, kaTimeout, actTimeout),
+		ResponseHeaderTimeout: actTimeout,
 		MaxIdleConnsPerHost:   10,
 	}
 	return &http.Client{Transport: transport}
@@ -27,16 +38,23 @@ func ClientWithTimeout(timeout time.Duration) *http.Client {
 // inactivity timeout for the given duration.  This is designed for long running
 // HTTP requests.
 func DialWithTimeout(timeout time.Duration) func(netw, addr string) (net.Conn, error) {
+	return DialWithTimeouts(timeout, timeout, timeout)
+}
+
+// DialWithTimeouts creates a Dial function that returns a connection with
+// separate timeouts for dialing the connection, maintaining the keep-alive
+// connection, and inactivity.  This is designed for long running HTTP requests.
+func DialWithTimeouts(dialTimeout, kaTimeout, actTimeout time.Duration) func(netw, addr string) (net.Conn, error) {
 	return func(netw, addr string) (net.Conn, error) {
-		c, err := net.DialTimeout(netw, addr, timeout)
+		c, err := net.DialTimeout(netw, addr, dialTimeout)
 		if err != nil {
 			return nil, err
 		}
 		if tc, ok := c.(*net.TCPConn); ok {
 			tc.SetKeepAlive(true)
-			tc.SetKeepAlivePeriod(timeout)
+			tc.SetKeepAlivePeriod(kaTimeout)
 		}
-		return &deadlineConn{timeout, c}, nil
+		return &deadlineConn{actTimeout, c}, nil
 	}
 }
 

--- a/http_client.go
+++ b/http_client.go
@@ -49,9 +49,8 @@ func DialWithTimeout(timeout time.Duration) func(netw, addr string) (net.Conn, e
 	return NewDialer(timeout).Dial
 }
 
-// DialWithTimeouts creates a Dial function that returns a connection with
-// separate timeouts for dialing the connection, maintaining the keep-alive
-// connection, and inactivity.  This is designed for long running HTTP requests.
+// NewDialer creates a dialer object with configurable timeoutes for keep alive
+// and inactivity.
 func NewDialer(timeout time.Duration) *dialer {
 	return &dialer{Timeout: timeout, KeepAlive: timeout, Inactivity: timeout}
 }


### PR DESCRIPTION
This lets you set different timeout durations for the connection dialing, keep alive connection, and inactivity.
